### PR TITLE
feature: Update to use django language_code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,13 +28,8 @@ Installation
 4. Sometimes you might want to limit size of uploaded images, e.g. if they are too large. In this case just put in settings (if you omit this, the image will be uploaded unchanged)::
 
     TRUMBOWYG_THUMBNAIL_SIZE = (1920, 1080)
-	
-5. The package will look for ``LANGUAGES`` setting. Please make sure you have set it otherwise **ALL** available language files will be loaded, and apparently this is not what you want::
 
-    LANGUAGES = (
-        ('en', 'English'),
-        ('ru', 'Russian'),
-    )
+5. The package will try to use the language defined in ``LANGUAGE_CODE`` and if this language isin't availabe the default is ``en`` 
 
 6. (Optional) If you wish image filenames to be transliterated, install `transliterate <https://pypi.python.org/pypi/transliterate>`_ from PyPi and set::
 

--- a/trumbowyg/widgets.py
+++ b/trumbowyg/widgets.py
@@ -2,13 +2,24 @@
 from django.conf import settings
 from django.forms.widgets import Textarea
 from django.utils.safestring import mark_safe
-from django.utils.translation import get_language, get_language_info
+from django.utils.translation import get_language
 
 try:
     from django.urls import reverse
 except ImportError:
     # For old versions of django
     from django.core.urlresolvers import reverse
+
+
+def get_trumbowyg_language():
+    """
+    Converte language from django to trumbowyg formate
+
+    Example:
+        Django uses: pt-br and trumbowyg use pt_br
+    """
+    return get_language().replace('-', '_')
+
 
 
 class TrumbowygWidget(Textarea):
@@ -23,7 +34,8 @@ class TrumbowygWidget(Textarea):
             '//ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js',
             'trumbowyg/trumbowyg.min.js',
             'trumbowyg/plugins/upload/trumbowyg.upload.js',
-        ] + ['trumbowyg/langs/%s.min.js' % x[0] for x in settings.LANGUAGES]
+            'trumbowyg/langs/{0}.min.js'.format(get_trumbowyg_language())
+        ]
 
     def render(self, name, value, attrs=None):
         output = super(TrumbowygWidget, self).render(name, value, attrs)
@@ -64,6 +76,6 @@ class TrumbowygWidget(Textarea):
                     }
                 });
             </script>
-        ''' % (name, get_language_info(get_language())['code'], reverse('trumbowyg_upload_image'))
+        ''' % (name, get_trumbowyg_language(), reverse('trumbowyg_upload_image'))
         output += mark_safe(script)
         return output


### PR DESCRIPTION
Now the django-trumbowyg always try to get the Django ```LANGUAGE_CODE``` to use as the default language, instead to iterate over all languages. So now is not necessary anymore define a language in the settings.

I think we need to update the available languages in the repository as well

I also create a language converter because Django use's ```-``` and we use ```underscore```